### PR TITLE
Adding ModelEvaluation class

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -283,6 +283,47 @@ Please visit `Importing models to Vertex AI`_ for a detailed overview:
 
 .. _Importing models to Vertex AI: https://cloud.google.com/vertex-ai/docs/general/import-model
 
+Model Evaluation
+----------------
+
+The Vertex AI SDK for Python currently supports getting model evaluation metrics for all AutoML models.
+
+To list all model evaluations for a model:
+
+.. code-block:: Python
+
+  model = aiplatform.Model('/projects/my-project/locations/us-central1/models/{MODEL_ID}')
+
+  evaluations = model.list_model_evaluations()
+  
+
+To get the model evaluation resource for a given model:
+
+.. code-block:: Python
+
+  model = aiplatform.Model('/projects/my-project/locations/us-central1/models/{MODEL_ID}')
+
+  # returns the first evaluation with no arguments, you can also pass the evaluation ID
+  evaluation = model.get_model_evaluation()
+
+  eval_metrics = evaluation.metrics
+
+
+You can also create a reference to your model evaluation directly by passing in the resource name of the model evaluation:
+
+.. code-block:: Python
+
+  evaluation = aiplatform.ModelEvaluation(
+    evaluation_name='/projects/my-project/locations/us-central1/models/{MODEL_ID}/evaluations/{EVALUATION_ID}')
+
+Alternatively, you can create a reference to your evaluation by passing in the model and evaluation IDs:
+
+.. code-block:: Python
+
+  evaluation = aiplatform.ModelEvaluation(
+    evaluation_name={EVALUATION_ID},
+    model_id={MODEL_ID})
+
 
 Batch Prediction
 ----------------

--- a/google/cloud/aiplatform/__init__.py
+++ b/google/cloud/aiplatform/__init__.py
@@ -108,6 +108,7 @@ __all__ = (
     "ImageDataset",
     "HyperparameterTuningJob",
     "Model",
+    "ModelEvaluation",
     "PipelineJob",
     "TabularDataset",
     "Tensorboard",

--- a/google/cloud/aiplatform/__init__.py
+++ b/google/cloud/aiplatform/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2020 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/google/cloud/aiplatform/__init__.py
+++ b/google/cloud/aiplatform/__init__.py
@@ -41,7 +41,6 @@ from google.cloud.aiplatform.featurestore import (
 from google.cloud.aiplatform.metadata import metadata
 from google.cloud.aiplatform.models import Endpoint
 from google.cloud.aiplatform.models import Model
-from google.cloud.aiplatform.model_evaluation import ModelEvaluation
 from google.cloud.aiplatform.jobs import (
     BatchPredictionJob,
     CustomJob,

--- a/google/cloud/aiplatform/__init__.py
+++ b/google/cloud/aiplatform/__init__.py
@@ -41,6 +41,7 @@ from google.cloud.aiplatform.featurestore import (
 from google.cloud.aiplatform.metadata import metadata
 from google.cloud.aiplatform.models import Endpoint
 from google.cloud.aiplatform.models import Model
+from google.cloud.aiplatform.model_evaluation import ModelEvaluation
 from google.cloud.aiplatform.jobs import (
     BatchPredictionJob,
     CustomJob,

--- a/google/cloud/aiplatform/model_evaluation/__init__.py
+++ b/google/cloud/aiplatform/model_evaluation/__init__.py
@@ -17,6 +17,4 @@
 
 from google.cloud.aiplatform.model_evaluation.model_evaluation import ModelEvaluation
 
-__all__ = (
-    "ModelEvaluation",
-)
+__all__ = ("ModelEvaluation",)

--- a/google/cloud/aiplatform/model_evaluation/__init__.py
+++ b/google/cloud/aiplatform/model_evaluation/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from google.cloud.aiplatform.model_evaluation.model_evaluation import ModelEvaluation
+
+__all__ = (
+    "ModelEvaluation",
+)

--- a/google/cloud/aiplatform/model_evaluation/model_evaluation.py
+++ b/google/cloud/aiplatform/model_evaluation/model_evaluation.py
@@ -48,8 +48,8 @@ class ModelEvaluation(base.VertexAiResourceNounWithFutureManager):
             pipeline output artifact. Returns None if the underlying
             PipelineJob has not yet completed.
         """
-        # print(self.api_client.get_model_evaluation())
-        # return self.api_client.get_model_evaluation()
+        if self._gca_resource.metrics:
+            return self.to_dict()['metrics']
 
     def __init__(
         self,

--- a/google/cloud/aiplatform/model_evaluation/model_evaluation.py
+++ b/google/cloud/aiplatform/model_evaluation/model_evaluation.py
@@ -39,54 +39,13 @@ class ModelEvaluation(base.VertexAiResourceNounWithFutureManager):
     _format_resource_name_method = "model_evaluation_path"
 
     @property
-    def evaluation_metrics(self) -> Optional[Dict[str, Any]]:
+    def metrics(self) -> Optional[Dict[str, Any]]:
         """Gets the evaluation metrics from the Model Evaluation.
         Returns:
             A dict with model metrics created from the Model Evaluation or
             None if the metrics for this evaluation are empty.
         """
-        if self._gca_resource.metrics:
-            return self.to_dict()["metrics"]
-
-    @property
-    def summary_metrics(self) -> Optional[Dict[str, Any]]:
-        """Gets the summary metrics for the Model Evaluation.
-
-        For classification models, this includes auPrc, auRoc, logLoss for the model overall,
-        and precision, recall, and F1 score at a confidence threshold of 0.5.
-
-        For regression models, the summary metrics are the same as `evaluation_metrics`.
-        This includes RMSE, MAE, MAPE, r^2, and RMSLE.
-
-        Returns:
-            A dict with model metrics created from the Model Evaluation or
-            None if the metrics for this evaluation are empty.
-        """
-
-        if self._gca_resource.metrics:
-            metrics = self.to_dict()["metrics"]
-            summary_metrics = {}
-
-            # classification
-            if "auPrc" in metrics:
-                summary_metrics["auPrc"] = metrics["auPrc"]
-                summary_metrics["auRoc"] = metrics["auRoc"]
-                summary_metrics["logLoss"] = metrics["logLoss"]
-
-                for confidence_slice in metrics["confidenceMetrics"]:
-                    if (
-                        "confidenceThreshold" in confidence_slice
-                        and confidence_slice["confidenceThreshold"] == 0.5
-                    ):
-                        summary_metrics["recall"] = confidence_slice["recall"]
-                        summary_metrics["precision"] = confidence_slice["precision"]
-                        summary_metrics["f1Score"] = confidence_slice["f1Score"]
-
-            # regression
-            if "rootMeanSquaredError" in metrics:
-                summary_metrics = metrics
-
-            return summary_metrics
+        return self._gca_resource.metrics
 
     def __init__(
         self,

--- a/google/cloud/aiplatform/model_evaluation/model_evaluation.py
+++ b/google/cloud/aiplatform/model_evaluation/model_evaluation.py
@@ -40,16 +40,16 @@ class ModelEvaluation(base.VertexAiResourceNounWithFutureManager):
     _parse_resource_name_method = "parse_model_evaluation_path"
     _format_resource_name_method = "model_evaluation_path"
 
+    # TODO: should this have an option for only returning summary metrics?
     @property
     def evaluation_metrics(self) -> Optional[Dict[str, Any]]:
         """Gets the evaluation metrics from the Model Evaluation.
         Returns:
-            A dict with model metrics created from the system.Metrics
-            pipeline output artifact. Returns None if the underlying
-            PipelineJob has not yet completed.
+            A dict with model metrics created from the Model Evaluation or
+            None if the metrics for this evaluation are empty.
         """
         if self._gca_resource.metrics:
-            return self.to_dict()['metrics']
+            return self.to_dict()["metrics"]
 
     def __init__(
         self,

--- a/google/cloud/aiplatform/model_evaluation/model_evaluation.py
+++ b/google/cloud/aiplatform/model_evaluation/model_evaluation.py
@@ -20,12 +20,9 @@ from google.auth import credentials as auth_credentials
 from google.cloud.aiplatform import base
 from google.cloud.aiplatform import utils
 from google.cloud.aiplatform import models
+from google.protobuf import struct_pb2
 
-from typing import (
-    Any,
-    Dict,
-    Optional,
-)
+from typing import Optional
 
 
 class ModelEvaluation(base.VertexAiResourceNounWithFutureManager):
@@ -39,7 +36,7 @@ class ModelEvaluation(base.VertexAiResourceNounWithFutureManager):
     _format_resource_name_method = "model_evaluation_path"
 
     @property
-    def metrics(self) -> Optional[Dict[str, Any]]:
+    def metrics(self) -> Optional[struct_pb2.Value]:
         """Gets the evaluation metrics from the Model Evaluation.
         Returns:
             A dict with model metrics created from the Model Evaluation or

--- a/google/cloud/aiplatform/model_evaluation/model_evaluation.py
+++ b/google/cloud/aiplatform/model_evaluation/model_evaluation.py
@@ -23,8 +23,6 @@ from google.cloud.aiplatform import pipeline_jobs
 from google.cloud.aiplatform import jobs
 from google.cloud.aiplatform import utils
 
-from google.cloud.aiplatform.utils import model_evaluation_utils
-
 from typing import (
     Any,
     Dict,
@@ -50,70 +48,8 @@ class ModelEvaluation(base.VertexAiResourceNounWithFutureManager):
             pipeline output artifact. Returns None if the underlying
             PipelineJob has not yet completed.
         """
-
-    @property
-    def batch_prediction_job(self) -> Optional[jobs.BatchPredictionJob]:
-        """The Batch Prediction job used for the Model Eval"""
-        # TODO: get this from the backing_pipeline_job property
-
-    @property
-    def backing_pipeline_job(self) -> Optional[pipeline_jobs.PipelineJob]:
-        """The PipelineJob resource that ran this model evaluation."""
-
-    @classmethod
-    def get_from_pipeline_job(
-        cls,
-        pipeline_job_id: Optional[str] = None,
-        pipeline_job: Optional[pipeline_jobs.PipelineJob] = None,
-        project: Optional[str] = None,
-        location: Optional[str] = None,
-        credentials: Optional[auth_credentials.Credentials] = None,
-    ) -> "ModelEvaluation":
-        """Creates a ModelEvaluation SDK resource from an evaluation pipeline that has already run on a managed Vertex model.
-        Args:
-            pipeline_job_id (str):
-                Optional. A fully-qualified pipeline job run ID.
-                Example: "projects/123/locations/us-central1/pipelineJobs/456" or
-                "456" when project and location are initialized or passed. One of `pipeline_job_id` or `pipeline_job` is required.
-            pipeline_job (aiplatform.PipelineJob):
-                Optional. An aiplatform.PipelineJob resource to create the ModelEvaluation from. One of `pipeline_job` or `pipeline_job_id` is required.
-            project (str):
-                Optional project to retrieve model evaluation from. If not set, project
-                set in aiplatform.init will be used.
-            location (str):
-                Optional location to retrieve model evaluation from. If not set, location
-                set in aiplatform.init will be used.
-            credentials: Optional[auth_credentials.Credentials]=None,
-                Custom credentials to use to retrieve this model evaluation. If not set,
-                credentials set in aiplatform.init will be used.
-
-        Returns:
-            A Vertex AI ModelEvaluation resource.
-        Raises:
-            ValueError: if neither pipeline_job_id or pipeline_job is provided.
-            ValueError: if the provided pipeline_job_id is not a ModelEvaluation pipeline.
-        """
-
-        if pipeline_job_id is None and pipeline_job is None:
-            raise ValueError(
-                "Please provide either a pipeline_job_id or pipeline_job. Neither were passed."
-            )
-
-        if pipeline_job_id is not None:
-            pipeline_job_resource = pipeline_jobs.PipelineJob.get(
-                resource_name=pipeline_job_id,
-                project=project,
-                location=location,
-                credentials=credentials,
-            )
-        else:
-            pipeline_job_resource = pipeline_job
-
-        if model_evaluation_utils._validate_model_evaluation_pipeline(
-            pipeline_job_resource
-        ):
-            # TODO: create and return the ModelEvaluation resource and set backing_pipeline_job
-            print("creating ModelEvaluation resource...")
+        # print(self.api_client.get_model_evaluation())
+        # return self.api_client.get_model_evaluation()
 
     def __init__(
         self,

--- a/google/cloud/aiplatform/model_evaluation/model_evaluation.py
+++ b/google/cloud/aiplatform/model_evaluation/model_evaluation.py
@@ -51,6 +51,7 @@ class ModelEvaluation(base.VertexAiResourceNounWithFutureManager):
         if self._gca_resource.metrics:
             return self.to_dict()["metrics"]
 
+    # TODO: can this be initialized with an eval ID only if a model is passed in?
     def __init__(
         self,
         evaluation_name: str,

--- a/google/cloud/aiplatform/model_evaluation/model_evaluation.py
+++ b/google/cloud/aiplatform/model_evaluation/model_evaluation.py
@@ -32,7 +32,7 @@ class ModelEvaluation(base.VertexAiResourceNounWithFutureManager):
 
     client_class = utils.ModelClientWithOverride
     _resource_noun = "evaluations"
-    _delete_method = "delete_pipeline_job"
+    _delete_method = None
     _getter_method = "get_model_evaluation"
     _list_method = "list_model_evaluations"
     _parse_resource_name_method = "parse_model_evaluation_path"
@@ -88,4 +88,9 @@ class ModelEvaluation(base.VertexAiResourceNounWithFutureManager):
             parent_resource_name_fields={models.Model._resource_noun: model_id}
             if model_id
             else model_id,
+        )
+
+    def delete(self):
+        raise NotImplementedError(
+            "Deleting a model evaluation has not been implemented yet."
         )

--- a/google/cloud/aiplatform/model_evaluation/model_evaluation.py
+++ b/google/cloud/aiplatform/model_evaluation/model_evaluation.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from google.auth import credentials as auth_credentials
+
+from google.cloud.aiplatform import base
+from google.cloud.aiplatform import initializer
+from google.cloud.aiplatform import pipeline_jobs
+from google.cloud.aiplatform import jobs
+from google.cloud.aiplatform import utils
+
+from google.cloud.aiplatform.utils import model_evaluation_utils
+
+from typing import (
+    Any,
+    Dict,
+    Optional,
+)
+
+
+class ModelEvaluation(base.VertexAiResourceNounWithFutureManager):
+
+    client_class = utils.ModelClientWithOverride
+    _resource_noun = "evaluations"
+    _delete_method = "delete_pipeline_job"
+    _getter_method = "get_model_evaluation"
+    _list_method = "list_model_evaluations"
+    _parse_resource_name_method = "parse_model_evaluation_path"
+    _format_resource_name_method = "model_evaluation_path"
+
+    @property
+    def evaluation_metrics(self) -> Optional[Dict[str, Any]]:
+        """Gets the evaluation metrics from the Model Evaluation.
+        Returns:
+            A dict with model metrics created from the system.Metrics
+            pipeline output artifact. Returns None if the underlying
+            PipelineJob has not yet completed.
+        """
+
+    @property
+    def batch_prediction_job(self) -> Optional[jobs.BatchPredictionJob]:
+        """The Batch Prediction job used for the Model Eval"""
+        # TODO: get this from the backing_pipeline_job property
+
+    @property
+    def backing_pipeline_job(self) -> Optional[pipeline_jobs.PipelineJob]:
+        """The PipelineJob resource that ran this model evaluation."""
+
+    @classmethod
+    def get_from_pipeline_job(
+        cls,
+        pipeline_job_id: Optional[str] = None,
+        pipeline_job: Optional[pipeline_jobs.PipelineJob] = None,
+        project: Optional[str] = None,
+        location: Optional[str] = None,
+        credentials: Optional[auth_credentials.Credentials] = None,
+    ) -> "ModelEvaluation":
+        """Creates a ModelEvaluation SDK resource from an evaluation pipeline that has already run on a managed Vertex model.
+        Args:
+            pipeline_job_id (str):
+                Optional. A fully-qualified pipeline job run ID.
+                Example: "projects/123/locations/us-central1/pipelineJobs/456" or
+                "456" when project and location are initialized or passed. One of `pipeline_job_id` or `pipeline_job` is required.
+            pipeline_job (aiplatform.PipelineJob):
+                Optional. An aiplatform.PipelineJob resource to create the ModelEvaluation from. One of `pipeline_job` or `pipeline_job_id` is required.
+            project (str):
+                Optional project to retrieve model evaluation from. If not set, project
+                set in aiplatform.init will be used.
+            location (str):
+                Optional location to retrieve model evaluation from. If not set, location
+                set in aiplatform.init will be used.
+            credentials: Optional[auth_credentials.Credentials]=None,
+                Custom credentials to use to retrieve this model evaluation. If not set,
+                credentials set in aiplatform.init will be used.
+
+        Returns:
+            A Vertex AI ModelEvaluation resource.
+        Raises:
+            ValueError: if neither pipeline_job_id or pipeline_job is provided.
+            ValueError: if the provided pipeline_job_id is not a ModelEvaluation pipeline.
+        """
+
+        if pipeline_job_id is None and pipeline_job is None:
+            raise ValueError(
+                "Please provide either a pipeline_job_id or pipeline_job. Neither were passed."
+            )
+
+        if pipeline_job_id is not None:
+            pipeline_job_resource = pipeline_jobs.PipelineJob.get(
+                resource_name=pipeline_job_id,
+                project=project,
+                location=location,
+                credentials=credentials,
+            )
+        else:
+            pipeline_job_resource = pipeline_job
+
+        if model_evaluation_utils._validate_model_evaluation_pipeline(
+            pipeline_job_resource
+        ):
+            # TODO: create and return the ModelEvaluation resource and set backing_pipeline_job
+            print("creating ModelEvaluation resource...")
+
+    def __init__(
+        self,
+        evaluation_name: str,
+        project: Optional[str] = None,
+        location: Optional[str] = None,
+        credentials: Optional[auth_credentials.Credentials] = None,
+    ):
+        """Retrieves the ModelEvaluation resource and instantiates its representation.
+
+        Args:
+            evaluation_name (str):
+                Required. A fully-qualified model evaluation resource name or evaluation ID.
+                Example: "projects/123/locations/us-central1/models/456/evaluations/789" or
+                "789" when project and location are initialized or passed.
+            project (str):
+                Optional project to retrieve model evaluation from. If not set, project
+                set in aiplatform.init will be used.
+            location (str):
+                Optional location to retrieve model evaluation from. If not set, location
+                set in aiplatform.init will be used.
+            credentials: Optional[auth_credentials.Credentials]=None,
+                Custom credentials to use to retrieve this model evaluation. If not set,
+                credentials set in aiplatform.init will be used.
+        """
+
+        super().__init__(
+            project=project,
+            location=location,
+            credentials=credentials,
+            resource_name=evaluation_name,
+        )
+
+        self._gca_resource = self._get_gca_resource(resource_name=evaluation_name)

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -3277,9 +3277,11 @@ class Model(base.VertexAiResourceNounWithFutureManager):
             )
         else:
             resource_uri_parts = self._parse_resource_name(self.resource_name)
-            evaluation_resource_name = model_evaluation.ModelEvaluation._format_resource_name(
-                **resource_uri_parts,
-                evaluation=evaluation_id,
+            evaluation_resource_name = (
+                model_evaluation.ModelEvaluation._format_resource_name(
+                    **resource_uri_parts,
+                    evaluation=evaluation_id,
+                )
             )
 
         return model_evaluation.ModelEvaluation(

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -3214,9 +3214,6 @@ class Model(base.VertexAiResourceNounWithFutureManager):
 
     def list_model_evaluations(
         self,
-        project: Optional[str] = None,
-        location: Optional[str] = None,
-        credentials: Optional[auth_credentials.Credentials] = None,
     ) -> List["model_evaluation.ModelEvaluation"]:
         """List all Model Evaluation resources associated with this model.
 
@@ -3228,16 +3225,6 @@ class Model(base.VertexAiResourceNounWithFutureManager):
 
         my_evaluations = my_model.list_model_evaluations()
 
-        Args:
-            project: Optional[str]=None,
-                Project to get model evaluations from. Overrides project set in
-                aiplatform.init.
-            location: Optional[str]=None,
-                Location to get model evaluations from. Overrides location set in
-                aiplatform.init.
-            credentials: Optional[auth_credentials.Credentials]=None,
-                Custom credentials to get model evaluations from. Overrides credentials
-                set in aiplatform.init.
         Returns:
             List[model_evaluation.ModelEvaluation]: List of ModelEvaluation resources
             for the model.
@@ -3247,16 +3234,11 @@ class Model(base.VertexAiResourceNounWithFutureManager):
             resource_noun=Model._resource_noun,
             parse_resource_name_method=Model._parse_resource_name,
             format_resource_name_method=Model._format_resource_name,
-            project=project,
-            location=location,
         )
 
         self.wait()
 
         return model_evaluation.ModelEvaluation._list(
-            project=project,
-            location=location,
-            credentials=credentials,
             parent=parent,
         )
 
@@ -3289,15 +3271,18 @@ class Model(base.VertexAiResourceNounWithFutureManager):
             ModelEvaluation resource.
         """
         if not evaluation_id:
-            evaluation_resource_name = self.list_model_evaluations(self.resource_name)[
-                0
-            ].resource_name
+            evaluation_resource_name = self.list_model_evaluations()[0].resource_name
+            _LOGGER.warning(
+                f"Your model has more than one model evaluation, this is returning only one evaluation resource: {evaluation_resource_name}"
+            )
         else:
-            # TODO: validate evaluation_id
-            evaluation_resource_name = (
-                f"{self.resource_name}/evaluations/{evaluation_id}"
+            resource_uri_parts = self._parse_resource_name(self.resource_name)
+            evaluation_resource_name = model_evaluation.ModelEvaluation._format_resource_name(
+                **resource_uri_parts,
+                evaluation=evaluation_id,
             )
 
         return model_evaluation.ModelEvaluation(
             evaluation_name=evaluation_resource_name,
+            credentials=self.credentials,
         )

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -51,6 +51,8 @@ from google.cloud.aiplatform.compat.types import (
 
 from google.protobuf import field_mask_pb2, json_format
 
+from google.cloud.aiplatform_v1.types import model_evaluation
+
 _DEFAULT_MACHINE_TYPE = "n1-standard-2"
 
 _LOGGER = base.Logger(__name__)
@@ -3219,7 +3221,7 @@ class Model(base.VertexAiResourceNounWithFutureManager):
         project: Optional[str] = None,
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
-    ) -> List["ModelEvaluation"]:
+    ) -> Optional[List["ModelEvaluation"]]:
 
         parent = utils.full_resource_name(
             resource_name=model_name,
@@ -3236,3 +3238,20 @@ class Model(base.VertexAiResourceNounWithFutureManager):
             credentials=credentials,
             parent=parent,
         )
+    
+    def get_model_evaluation(
+        self,
+        evaluation_name: Optional[str] = None,
+        project: Optional[str] = None,
+        location: Optional[str] = None,
+        credentials: Optional[auth_credentials.Credentials] = None,
+    ) -> Optional[model_evaluation.ModelEvaluation]:
+        """Returns and instantiates the provided ModelEvaluation. If no evaluation_name is passed, 
+        it will return the first evaluation associated with this model.
+        """
+
+        if not evaluation_name:
+            evaluation_name = Model.list_model_evaluations(self.resource_name)[0].resource_name
+
+        return ModelEvaluation(evaluation_name=evaluation_name)
+        

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -3222,7 +3222,34 @@ class Model(base.VertexAiResourceNounWithFutureManager):
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
     ) -> Optional[List["ModelEvaluation"]]:
+        """List all Model Evaluation resources associated with this model.
 
+        Example Usage:
+
+        aiplatform.Model.list_model_evaluations(
+            model_name="projects/123/locations/us-central1/models/456"
+        )
+
+        aiplatform.Model.list_model_evaluations(
+            model_name="456"
+        )
+
+        Args:
+            model_name (str):
+                Required. A fully-qualified model resource name or model ID.
+                Example: "projects/123/locations/us-central1/models/456" or
+                "456" when project and location are initialized or passed.
+            project: Optional[str]=None,
+                Project to get model evaluations from. Overrides project set in
+                aiplatform.init.
+            location: Optional[str]=None,
+                Location to get model evaluations from. Overrides location set in
+                aiplatform.init.
+            credentials: Optional[auth_credentials.Credentials]=None,
+                Custom credentials to get model evaluations from. Overrides credentials
+                set in aiplatform.init.
+        """
+    
         parent = utils.full_resource_name(
             resource_name=model_name,
             resource_noun=Model._resource_noun,
@@ -3246,8 +3273,33 @@ class Model(base.VertexAiResourceNounWithFutureManager):
         location: Optional[str] = None,
         credentials: Optional[auth_credentials.Credentials] = None,
     ) -> Optional[model_evaluation.ModelEvaluation]:
-        """Returns and instantiates the provided ModelEvaluation. If no evaluation_name is passed, 
-        it will return the first evaluation associated with this model.
+        """Returns a ModelEvaluation resource and instantiates its representation.
+        If no evaluation_name is passed, it will return the first evaluation associated
+        with this model.
+
+        Example usage:
+
+            my_evaluation = my_model.get_model_evaluation(
+                evaluation_name="projects/123/locations/us-central1/models/456/evaluations/789"
+            )
+
+            # Gets first ModelEvaluation
+            my_evaluation = my_model.get_model_evaluation()
+
+        Args:
+            evaluation_name (str):
+                Optional. A fully-qualified evaluation resource name or evaluation ID.
+                Example: "projects/123/locations/us-central1/models/456/evaluations/789" or
+                "789" when project and location are initialized or passed.
+            project: Optional[str]=None,
+                Project to get this evaluation from. Overrides project set in
+                aiplatform.init.
+            location: Optional[str]=None,
+                Location to get this evaluation from. Overrides location set in
+                aiplatform.init.
+            credentials: Optional[auth_credentials.Credentials]=None,
+                Custom credentials to get this evaluation from. Overrides credentials
+                set in aiplatform.init.
         """
 
         if not evaluation_name:

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -3222,19 +3222,13 @@ class Model(base.VertexAiResourceNounWithFutureManager):
 
         Example Usage:
 
-        aiplatform.Model.list_model_evaluations(
+        my_model = Model(
             model_name="projects/123/locations/us-central1/models/456"
         )
 
-        aiplatform.Model.list_model_evaluations(
-            model_name="456"
-        )
+        my_evaluations = my_model.list_model_evaluations()
 
         Args:
-            model_name (str):
-                Required. A fully-qualified model resource name or model ID.
-                Example: "projects/123/locations/us-central1/models/456" or
-                "456" when project and location are initialized or passed.
             project: Optional[str]=None,
                 Project to get model evaluations from. Overrides project set in
                 aiplatform.init.
@@ -3244,6 +3238,9 @@ class Model(base.VertexAiResourceNounWithFutureManager):
             credentials: Optional[auth_credentials.Credentials]=None,
                 Custom credentials to get model evaluations from. Overrides credentials
                 set in aiplatform.init.
+        Returns:
+            List[model_evaluation.ModelEvaluation]: List of ModelEvaluation resources
+            for the model.
         """
         parent = utils.full_resource_name(
             resource_name=self.resource_name,
@@ -3273,6 +3270,10 @@ class Model(base.VertexAiResourceNounWithFutureManager):
 
         Example usage:
 
+            my_model = Model(
+                model_name="projects/123/locations/us-central1/models/456"
+            )
+
             my_evaluation = my_model.get_model_evaluation(
                 evaluation_id="789"
             )
@@ -3283,6 +3284,9 @@ class Model(base.VertexAiResourceNounWithFutureManager):
         Args:
             evaluation_id (str):
                 Optional. The ID of the model evaluation to retrieve.
+        Returns:
+            model_evaluation.ModelEvaluation: Instantiated representation of the
+            ModelEvaluation resource.
         """
         if not evaluation_id:
             evaluation_resource_name = self.list_model_evaluations(self.resource_name)[

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -3214,6 +3214,7 @@ class Model(base.VertexAiResourceNounWithFutureManager):
             upload_request_timeout=upload_request_timeout,
         )
 
+    # TODO: should this have a sync param?
     @classmethod
     def list_model_evaluations(
         cls,
@@ -3266,6 +3267,7 @@ class Model(base.VertexAiResourceNounWithFutureManager):
             parent=parent,
         )
     
+    # TODO: same question about a sync param
     def get_model_evaluation(
         self,
         evaluation_name: Optional[str] = None,

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -3229,17 +3229,12 @@ class Model(base.VertexAiResourceNounWithFutureManager):
             List[model_evaluation.ModelEvaluation]: List of ModelEvaluation resources
             for the model.
         """
-        parent = utils.full_resource_name(
-            resource_name=self.resource_name,
-            resource_noun=Model._resource_noun,
-            parse_resource_name_method=Model._parse_resource_name,
-            format_resource_name_method=Model._format_resource_name,
-        )
 
         self.wait()
 
         return model_evaluation.ModelEvaluation._list(
-            parent=parent,
+            parent=self.resource_name,
+            credentials=self.credentials,
         )
 
     def get_model_evaluation(
@@ -3270,11 +3265,15 @@ class Model(base.VertexAiResourceNounWithFutureManager):
             model_evaluation.ModelEvaluation: Instantiated representation of the
             ModelEvaluation resource.
         """
+
+        evaluations = self.list_model_evaluations()
+
         if not evaluation_id:
-            evaluation_resource_name = self.list_model_evaluations()[0].resource_name
-            _LOGGER.warning(
-                f"Your model has more than one model evaluation, this is returning only one evaluation resource: {evaluation_resource_name}"
-            )
+            if len(evaluations) > 1:
+                _LOGGER.warning(
+                    f"Your model has more than one model evaluation, this is returning only one evaluation resource: {evaluations[0].resource_name}"
+                )
+            return evaluations[0] if evaluations else evaluations
         else:
             resource_uri_parts = self._parse_resource_name(self.resource_name)
             evaluation_resource_name = (
@@ -3284,7 +3283,7 @@ class Model(base.VertexAiResourceNounWithFutureManager):
                 )
             )
 
-        return model_evaluation.ModelEvaluation(
-            evaluation_name=evaluation_resource_name,
-            credentials=self.credentials,
-        )
+            return model_evaluation.ModelEvaluation(
+                evaluation_name=evaluation_resource_name,
+                credentials=self.credentials,
+            )

--- a/google/cloud/aiplatform/models.py
+++ b/google/cloud/aiplatform/models.py
@@ -33,6 +33,7 @@ from google.cloud.aiplatform import jobs
 from google.cloud.aiplatform import models
 from google.cloud.aiplatform import utils
 from google.cloud.aiplatform.utils import gcs_utils
+from google.cloud.aiplatform.model_evaluation import ModelEvaluation
 
 from google.cloud.aiplatform.compat.services import endpoint_service_client
 
@@ -3209,4 +3210,29 @@ class Model(base.VertexAiResourceNounWithFutureManager):
             staging_bucket=staging_bucket,
             sync=sync,
             upload_request_timeout=upload_request_timeout,
+        )
+
+    @classmethod
+    def list_model_evaluations(
+        cls,
+        model_name: str,
+        project: Optional[str] = None,
+        location: Optional[str] = None,
+        credentials: Optional[auth_credentials.Credentials] = None,
+    ) -> List["ModelEvaluation"]:
+
+        parent = utils.full_resource_name(
+            resource_name=model_name,
+            resource_noun=Model._resource_noun,
+            parse_resource_name_method=Model._parse_resource_name,
+            format_resource_name_method=Model._format_resource_name,
+            project=project,
+            location=location,
+        )
+
+        return ModelEvaluation._list(
+            project=project,
+            location=location,
+            credentials=credentials,
+            parent=parent,
         )

--- a/tests/unit/aiplatform/test_model_evaluation.py
+++ b/tests/unit/aiplatform/test_model_evaluation.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from multiprocessing.sharedctypes import Value
+from google.cloud.aiplatform import model_evaluation
+import yaml
+import datetime
+import os
+from typing import Type
+import pytest
+import json
+
+from unittest import mock
+from unittest.mock import patch
+from importlib import reload
+
+from google.api_core import operation
+from google.protobuf import json_format
+from google.cloud import storage
+
+from google.cloud import aiplatform
+from google.cloud.aiplatform import base
+from google.cloud.aiplatform import models
+from google.cloud.aiplatform import pipeline_jobs
+
+from google.cloud.aiplatform.model_evaluation import ModelEvaluation
+
+from google.cloud.aiplatform_v1.services.model_service import (
+    client as model_service_client,
+)
+
+
+
+from google.cloud.aiplatform.compat.types import model as gca_model
+
+from google.cloud.aiplatform_v1.types import (
+    model_evaluation as gca_model_evaluation,
+)
+
+# pipeline job
+_TEST_PROJECT = "test-project"
+_TEST_LOCATION = "us-central1"
+_TEST_PIPELINE_JOB_ID = "sample-test-pipeline-202111111"
+
+_TEST_ID = "1028944691210842416"
+
+_TEST_MODEL_RESOURCE_NAME = model_service_client.ModelServiceClient.model_path(
+    _TEST_PROJECT, _TEST_LOCATION, _TEST_ID
+)
+
+_TEST_MODEL_NAME = "test-model"
+
+_TEST_EVAL_RESOURCE_NAME = f"projects/{_TEST_ID}/locations/{_TEST_LOCATION}/models/{_TEST_ID}/evaluations/{_TEST_ID}"
+
+
+@pytest.fixture
+def get_model_mock():
+    with mock.patch.object(
+        model_service_client.ModelServiceClient, "get_model"
+    ) as get_model_mock:
+        get_model_mock.return_value = gca_model.Model(
+            display_name=_TEST_MODEL_NAME, name=_TEST_MODEL_RESOURCE_NAME,
+        )
+
+        yield get_model_mock
+
+
+@pytest.fixture
+def mock_model():
+    model = mock.MagicMock(models.Model)
+    model.name = _TEST_ID
+    # model.resource_name = _TEST_MODEL_RESOURCE_NAME,
+    model._latest_future = None
+    model._exception = None
+    model._gca_resource = gca_model.Model(
+        display_name="test-eval-model",
+        description="This is the mock Model's description",
+        name=_TEST_MODEL_NAME,
+    )
+    yield model
+
+
+# Mocks specific to ModelEvaluation
+
+
+@pytest.fixture
+def mock_model_eval_get():
+    with mock.patch.object(
+        model_service_client.ModelServiceClient, "get_model_evaluation"
+    ) as mock_get_model_eval:
+        mock_get_model_eval.return_value = gca_model_evaluation.ModelEvaluation(
+            name=_TEST_EVAL_RESOURCE_NAME
+        )
+        yield mock_get_model_eval
+
+
+class TestModelEvaluation:
+    def test_init_model_evaluation(self, mock_model_eval_get):
+        aiplatform.init(project=_TEST_PROJECT)
+
+        aiplatform.ModelEvaluation(
+            evaluation_name=_TEST_EVAL_RESOURCE_NAME
+        )
+
+        mock_model_eval_get.assert_called_once_with(
+            name=_TEST_EVAL_RESOURCE_NAME, retry=base._DEFAULT_RETRY
+        )
+
+    # TODO: test_init_model_evaluation_with_invalid_evaluation_resource_raises

--- a/tests/unit/aiplatform/test_model_evaluation.py
+++ b/tests/unit/aiplatform/test_model_evaluation.py
@@ -15,29 +15,13 @@
 # limitations under the License.
 #
 
-from multiprocessing.sharedctypes import Value
-from google.cloud.aiplatform import model_evaluation
-import yaml
-import datetime
-import os
-from typing import Type
 import pytest
-import json
 
 from unittest import mock
-from unittest.mock import patch
-from importlib import reload
-
-from google.api_core import operation
-from google.protobuf import json_format
-from google.cloud import storage
 
 from google.cloud import aiplatform
 from google.cloud.aiplatform import base
 from google.cloud.aiplatform import models
-from google.cloud.aiplatform import pipeline_jobs
-
-from google.cloud.aiplatform.model_evaluation import ModelEvaluation
 
 from google.cloud.aiplatform_v1.services.model_service import (
     client as model_service_client,
@@ -57,8 +41,13 @@ _TEST_MODEL_RESOURCE_NAME = model_service_client.ModelServiceClient.model_path(
     _TEST_PROJECT, _TEST_LOCATION, _TEST_MODEL_NAME
 )
 
-_TEST_MODEL_EVAL_RESOURCE_NAME = model_service_client.ModelServiceClient.model_evaluation_path(
-    _TEST_PROJECT, _TEST_LOCATION, _TEST_MODEL_NAME, _TEST_ID,
+_TEST_MODEL_EVAL_RESOURCE_NAME = (
+    model_service_client.ModelServiceClient.model_evaluation_path(
+        _TEST_PROJECT,
+        _TEST_LOCATION,
+        _TEST_MODEL_NAME,
+        _TEST_ID,
+    )
 )
 
 _TEST_MODEL_EVAL_METRICS = {
@@ -101,7 +90,8 @@ def get_model_mock():
         model_service_client.ModelServiceClient, "get_model"
     ) as get_model_mock:
         get_model_mock.return_value = gca_model.Model(
-            display_name=_TEST_MODEL_NAME, name=_TEST_MODEL_RESOURCE_NAME,
+            display_name=_TEST_MODEL_NAME,
+            name=_TEST_MODEL_RESOURCE_NAME,
         )
 
         yield get_model_mock
@@ -129,7 +119,8 @@ def mock_model_eval_get():
         model_service_client.ModelServiceClient, "get_model_evaluation"
     ) as mock_get_model_eval:
         mock_get_model_eval.return_value = gca_model_evaluation.ModelEvaluation(
-            name=_TEST_MODEL_EVAL_RESOURCE_NAME, metrics=_TEST_MODEL_EVAL_METRICS,
+            name=_TEST_MODEL_EVAL_RESOURCE_NAME,
+            metrics=_TEST_MODEL_EVAL_METRICS,
         )
         yield mock_get_model_eval
 

--- a/tests/unit/aiplatform/test_model_evaluation.py
+++ b/tests/unit/aiplatform/test_model_evaluation.py
@@ -101,7 +101,6 @@ def get_model_mock():
 def mock_model():
     model = mock.MagicMock(models.Model)
     model.name = _TEST_ID
-    # model.resource_name = _TEST_MODEL_RESOURCE_NAME,
     model._latest_future = None
     model._exception = None
     model._gca_resource = gca_model.Model(

--- a/tests/unit/aiplatform/test_model_evaluation.py
+++ b/tests/unit/aiplatform/test_model_evaluation.py
@@ -50,14 +50,16 @@ from google.cloud.aiplatform_v1.types import model_evaluation as gca_model_evalu
 
 _TEST_PROJECT = "test-project"
 _TEST_LOCATION = "us-central1"
+_TEST_MODEL_NAME = "test-model"
 _TEST_ID = "1028944691210842416"
 
 _TEST_MODEL_RESOURCE_NAME = model_service_client.ModelServiceClient.model_path(
-    _TEST_PROJECT, _TEST_LOCATION, _TEST_ID
+    _TEST_PROJECT, _TEST_LOCATION, _TEST_MODEL_NAME
 )
 
-_TEST_MODEL_NAME = "test-model"
-_TEST_EVAL_RESOURCE_NAME = f"projects/{_TEST_ID}/locations/{_TEST_LOCATION}/models/{_TEST_ID}/evaluations/{_TEST_ID}"
+_TEST_MODEL_EVAL_RESOURCE_NAME = model_service_client.ModelServiceClient.model_evaluation_path(
+    _TEST_PROJECT, _TEST_LOCATION, _TEST_MODEL_NAME, _TEST_ID,
+)
 
 _TEST_MODEL_EVAL_METRICS = {
     "auPrc": 0.80592036,
@@ -127,7 +129,7 @@ def mock_model_eval_get():
         model_service_client.ModelServiceClient, "get_model_evaluation"
     ) as mock_get_model_eval:
         mock_get_model_eval.return_value = gca_model_evaluation.ModelEvaluation(
-            name=_TEST_EVAL_RESOURCE_NAME, metrics=_TEST_MODEL_EVAL_METRICS,
+            name=_TEST_MODEL_EVAL_RESOURCE_NAME, metrics=_TEST_MODEL_EVAL_METRICS,
         )
         yield mock_get_model_eval
 
@@ -136,10 +138,10 @@ class TestModelEvaluation:
     def test_init_model_evaluation_with_resource_name(self, mock_model_eval_get):
         aiplatform.init(project=_TEST_PROJECT)
 
-        aiplatform.ModelEvaluation(evaluation_name=_TEST_EVAL_RESOURCE_NAME)
+        aiplatform.ModelEvaluation(evaluation_name=_TEST_MODEL_EVAL_RESOURCE_NAME)
 
         mock_model_eval_get.assert_called_once_with(
-            name=_TEST_EVAL_RESOURCE_NAME, retry=base._DEFAULT_RETRY
+            name=_TEST_MODEL_EVAL_RESOURCE_NAME, retry=base._DEFAULT_RETRY
         )
 
     def test_init_model_evaluation_with_invalid_evaluation_resource_raises(
@@ -154,6 +156,6 @@ class TestModelEvaluation:
         aiplatform.init(project=_TEST_PROJECT)
 
         eval_metrics = aiplatform.ModelEvaluation(
-            evaluation_name=_TEST_EVAL_RESOURCE_NAME
+            evaluation_name=_TEST_MODEL_EVAL_RESOURCE_NAME
         ).evaluation_metrics
         assert eval_metrics == _TEST_MODEL_EVAL_METRICS

--- a/tests/unit/aiplatform/test_model_evaluation.py
+++ b/tests/unit/aiplatform/test_model_evaluation.py
@@ -147,5 +147,5 @@ class TestModelEvaluation:
 
         eval_metrics = aiplatform.ModelEvaluation(
             evaluation_name=_TEST_MODEL_EVAL_RESOURCE_NAME
-        ).evaluation_metrics
+        ).metrics
         assert eval_metrics == _TEST_MODEL_EVAL_METRICS

--- a/tests/unit/aiplatform/test_model_evaluation.py
+++ b/tests/unit/aiplatform/test_model_evaluation.py
@@ -48,11 +48,8 @@ from google.cloud.aiplatform.compat.types import model as gca_model
 
 from google.cloud.aiplatform_v1.types import model_evaluation as gca_model_evaluation
 
-# pipeline job
 _TEST_PROJECT = "test-project"
 _TEST_LOCATION = "us-central1"
-_TEST_PIPELINE_JOB_ID = "sample-test-pipeline-202111111"
-
 _TEST_ID = "1028944691210842416"
 
 _TEST_MODEL_RESOURCE_NAME = model_service_client.ModelServiceClient.model_path(
@@ -60,8 +57,40 @@ _TEST_MODEL_RESOURCE_NAME = model_service_client.ModelServiceClient.model_path(
 )
 
 _TEST_MODEL_NAME = "test-model"
-
 _TEST_EVAL_RESOURCE_NAME = f"projects/{_TEST_ID}/locations/{_TEST_LOCATION}/models/{_TEST_ID}/evaluations/{_TEST_ID}"
+
+_TEST_MODEL_EVAL_METRICS = {
+    "auPrc": 0.80592036,
+    "auRoc": 0.8100363,
+    "logLoss": 0.53061414,
+    "confidenceMetrics": [
+        {
+            "confidenceThreshold": -0.01,
+            "recall": 1.0,
+            "precision": 0.5,
+            "falsePositiveRate": 1.0,
+            "f1Score": 0.6666667,
+            "recallAt1": 1.0,
+            "precisionAt1": 0.5,
+            "falsePositiveRateAt1": 1.0,
+            "f1ScoreAt1": 0.6666667,
+            "truePositiveCount": "415",
+            "falsePositiveCount": "415",
+        },
+        {
+            "recall": 1.0,
+            "precision": 0.5,
+            "falsePositiveRate": 1.0,
+            "f1Score": 0.6666667,
+            "recallAt1": 0.74216866,
+            "precisionAt1": 0.74216866,
+            "falsePositiveRateAt1": 0.25783134,
+            "f1ScoreAt1": 0.74216866,
+            "truePositiveCount": "415",
+            "falsePositiveCount": "415",
+        },
+    ],
+}
 
 
 @pytest.fixture
@@ -91,22 +120,20 @@ def mock_model():
     yield model
 
 
-# Mocks specific to ModelEvaluation
-
-
+# ModelEvaluation mocks
 @pytest.fixture
 def mock_model_eval_get():
     with mock.patch.object(
         model_service_client.ModelServiceClient, "get_model_evaluation"
     ) as mock_get_model_eval:
         mock_get_model_eval.return_value = gca_model_evaluation.ModelEvaluation(
-            name=_TEST_EVAL_RESOURCE_NAME
+            name=_TEST_EVAL_RESOURCE_NAME, metrics=_TEST_MODEL_EVAL_METRICS,
         )
         yield mock_get_model_eval
 
 
 class TestModelEvaluation:
-    def test_init_model_evaluation(self, mock_model_eval_get):
+    def test_init_model_evaluation_with_resource_name(self, mock_model_eval_get):
         aiplatform.init(project=_TEST_PROJECT)
 
         aiplatform.ModelEvaluation(evaluation_name=_TEST_EVAL_RESOURCE_NAME)
@@ -115,4 +142,18 @@ class TestModelEvaluation:
             name=_TEST_EVAL_RESOURCE_NAME, retry=base._DEFAULT_RETRY
         )
 
-    # TODO: test_init_model_evaluation_with_invalid_evaluation_resource_raises
+    def test_init_model_evaluation_with_invalid_evaluation_resource_raises(
+        self, mock_model_eval_get
+    ):
+        aiplatform.init(project=_TEST_PROJECT)
+
+        with pytest.raises(ValueError):
+            aiplatform.ModelEvaluation(evaluation_name=_TEST_MODEL_RESOURCE_NAME)
+
+    def test_get_model_evaluation_metrics(self, mock_model_eval_get):
+        aiplatform.init(project=_TEST_PROJECT)
+
+        eval_metrics = aiplatform.ModelEvaluation(
+            evaluation_name=_TEST_EVAL_RESOURCE_NAME
+        ).evaluation_metrics
+        assert eval_metrics == _TEST_MODEL_EVAL_METRICS

--- a/tests/unit/aiplatform/test_model_evaluation.py
+++ b/tests/unit/aiplatform/test_model_evaluation.py
@@ -44,12 +44,9 @@ from google.cloud.aiplatform_v1.services.model_service import (
 )
 
 
-
 from google.cloud.aiplatform.compat.types import model as gca_model
 
-from google.cloud.aiplatform_v1.types import (
-    model_evaluation as gca_model_evaluation,
-)
+from google.cloud.aiplatform_v1.types import model_evaluation as gca_model_evaluation
 
 # pipeline job
 _TEST_PROJECT = "test-project"
@@ -112,9 +109,7 @@ class TestModelEvaluation:
     def test_init_model_evaluation(self, mock_model_eval_get):
         aiplatform.init(project=_TEST_PROJECT)
 
-        aiplatform.ModelEvaluation(
-            evaluation_name=_TEST_EVAL_RESOURCE_NAME
-        )
+        aiplatform.ModelEvaluation(evaluation_name=_TEST_EVAL_RESOURCE_NAME)
 
         mock_model_eval_get.assert_called_once_with(
             name=_TEST_EVAL_RESOURCE_NAME, retry=base._DEFAULT_RETRY

--- a/tests/unit/aiplatform/test_models.py
+++ b/tests/unit/aiplatform/test_models.py
@@ -1931,6 +1931,7 @@ class TestModel:
         self,
         mock_model_eval_get,
         get_model_mock,
+        list_model_evaluations_mock,
     ):
         test_model = models.Model(model_name=_TEST_MODEL_RESOURCE_NAME)
 
@@ -1950,8 +1951,8 @@ class TestModel:
 
         test_model.get_model_evaluation()
 
-        mock_model_eval_get.assert_called_once_with(
-            name=_TEST_MODEL_EVAL_RESOURCE_NAME, retry=base._DEFAULT_RETRY
+        list_model_evaluations_mock.assert_called_once_with(
+            request={"parent": _TEST_MODEL_RESOURCE_NAME, "filter": None}
         )
 
     def test_list_model_evaluations(

--- a/tests/unit/aiplatform/test_models.py
+++ b/tests/unit/aiplatform/test_models.py
@@ -185,7 +185,9 @@ _TEST_SUPPORTED_EXPORT_FORMATS_UNSUPPORTED = []
 _TEST_CONTAINER_REGISTRY_DESTINATION
 
 # Model Evaluation
-_TEST_EVAL_RESOURCE_NAME = f"{_TEST_MODEL_RESOURCE_NAME}/evaluations/{_TEST_ID}"
+_TEST_MODEL_EVAL_RESOURCE_NAME = model_service_client.ModelServiceClient.model_evaluation_path(
+    _TEST_PROJECT, _TEST_LOCATION, _TEST_MODEL_NAME, _TEST_ID,
+)
 _TEST_MODEL_EVAL_METRICS = {
     "auPrc": 0.80592036,
     "auRoc": 0.8100363,
@@ -221,13 +223,13 @@ _TEST_MODEL_EVAL_METRICS = {
 
 _TEST_MODEL_EVAL_LIST = [
     gca_model_evaluation.ModelEvaluation(
-        name=_TEST_EVAL_RESOURCE_NAME,
+        name=_TEST_MODEL_EVAL_RESOURCE_NAME,
     ),
     gca_model_evaluation.ModelEvaluation(
-        name=_TEST_EVAL_RESOURCE_NAME,
+        name=_TEST_MODEL_EVAL_RESOURCE_NAME,
     ),
     gca_model_evaluation.ModelEvaluation(
-        name=_TEST_EVAL_RESOURCE_NAME,
+        name=_TEST_MODEL_EVAL_RESOURCE_NAME,
     ),
 ]
 
@@ -523,7 +525,7 @@ def mock_model_eval_get():
         model_service_client.ModelServiceClient, "get_model_evaluation"
     ) as mock_get_model_eval:
         mock_get_model_eval.return_value = gca_model_evaluation.ModelEvaluation(
-            name=_TEST_EVAL_RESOURCE_NAME, metrics=_TEST_MODEL_EVAL_METRICS,
+            name=_TEST_MODEL_EVAL_RESOURCE_NAME, metrics=_TEST_MODEL_EVAL_METRICS,
         )
         yield mock_get_model_eval
 
@@ -1929,10 +1931,10 @@ class TestModel:
     ):
         test_model = models.Model(_TEST_ID)
 
-        test_model.get_model_evaluation(evaluation_name=_TEST_EVAL_RESOURCE_NAME)
+        test_model.get_model_evaluation(evaluation_name=_TEST_MODEL_EVAL_RESOURCE_NAME)
 
         mock_model_eval_get.assert_called_once_with(
-            name=_TEST_EVAL_RESOURCE_NAME, retry=base._DEFAULT_RETRY
+            name=_TEST_MODEL_EVAL_RESOURCE_NAME, retry=base._DEFAULT_RETRY
         )
     
     def test_list_model_evaluations(

--- a/tests/unit/aiplatform/test_models.py
+++ b/tests/unit/aiplatform/test_models.py
@@ -1948,7 +1948,7 @@ class TestModel:
     ):
         test_model = models.Model(model_name=_TEST_MODEL_RESOURCE_NAME)
 
-        eval = test_model.get_model_evaluation()
+        test_model.get_model_evaluation()
 
         mock_model_eval_get.assert_called_once_with(
             name=_TEST_MODEL_EVAL_RESOURCE_NAME, retry=base._DEFAULT_RETRY

--- a/tests/unit/aiplatform/test_models.py
+++ b/tests/unit/aiplatform/test_models.py
@@ -1944,6 +1944,7 @@ class TestModel:
         self,
         mock_model_eval_get,
         get_model_mock,
+        list_model_evaluations_mock,
     ):
         test_model = models.Model(model_name=_TEST_MODEL_RESOURCE_NAME)
 
@@ -1952,8 +1953,6 @@ class TestModel:
         mock_model_eval_get.assert_called_once_with(
             name=_TEST_MODEL_EVAL_RESOURCE_NAME, retry=base._DEFAULT_RETRY
         )
-
-        assert eval == _TEST_MODEL_EVAL_LIST[0]
 
     def test_list_model_evaluations(
         self,


### PR DESCRIPTION
Started work on ModelEvaluation class (without pipeline-based services). Added
* `model_evaluation/model_evaluation.py`
*  `list_model_evaluations` and `get_model_evaluation` methods to `models.py`
*  Initial tests in `test_model_evaluation.py` and `test_models.py`
