### PR TITLE
Example: Remove shared state from test_dataset.py

### DIFF
--- a/tests/system/aiplatform/test_dataset.py
+++ b/tests/system/aiplatform/test_dataset.py
@@ -22,7 +22,6 @@ import importlib
 
 import pandas as pd
 
-from google import auth as google_auth
 from google.api_core import exceptions
 from google.api_core import client_options
 
@@ -32,10 +31,9 @@ from google.cloud import aiplatform
 from google.cloud import storage
 from google.cloud.aiplatform import utils
 from google.cloud.aiplatform import initializer
-from google.cloud.aiplatform_v1beta1.types import dataset as gca_dataset
 from google.cloud.aiplatform_v1beta1.services import dataset_service
 
-from test_utils.vpcsc_config import vpcsc_config
+# from test_utils.vpcsc_config import vpcsc_config
 
 from tests.system.aiplatform import e2e_base
 
@@ -121,12 +119,6 @@ _TEST_DATAFRAME_BQ_SCHEMA = [
 ]
 
 
-@pytest.mark.usefixtures(
-    "prepare_staging_bucket",
-    "delete_staging_bucket",
-    "prepare_bigquery_dataset",
-    "delete_bigquery_dataset",
-)
 class TestDataset(e2e_base.TestEndToEnd):
 
     _temp_prefix = "temp-vertex-sdk-dataset-test"
@@ -135,14 +127,20 @@ class TestDataset(e2e_base.TestEndToEnd):
         importlib.reload(initializer)
         importlib.reload(aiplatform)
 
+        aiplatform.init(project=_TEST_PROJECT, location=_TEST_LOCATION)
+
     @pytest.fixture()
-    def create_staging_bucket(self, shared_state):
+    def storage_client(self):
+        yield storage.Client()
+
+    @pytest.fixture()
+    def staging_bucket(self, storage_client):
         new_staging_bucket = f"temp-sdk-integration-{uuid.uuid4()}"
-        storage_client = storage.Client()
-        storage_client.create_bucket(new_staging_bucket)
-        shared_state["storage_client"] = storage_client
-        shared_state["staging_bucket"] = new_staging_bucket
-        yield
+        bucket = storage_client.create_bucket(new_staging_bucket)
+
+        yield bucket
+
+        bucket.delete(force=True)
 
     @pytest.fixture()
     def dataset_gapic_client(self):
@@ -153,61 +151,14 @@ class TestDataset(e2e_base.TestEndToEnd):
         yield gapic_client
 
     @pytest.fixture()
-    def create_text_dataset(self, dataset_gapic_client, shared_state):
-
-        gapic_dataset = gca_dataset.Dataset(
+    def text_dataset(self):
+        dataset = aiplatform.TextDataset.create(
             display_name=f"temp_sdk_integration_test_create_text_dataset_{uuid.uuid4()}",
-            metadata_schema_uri=aiplatform.schema.dataset.metadata.text,
         )
 
-        create_lro = dataset_gapic_client.create_dataset(
-            parent=_TEST_PARENT, dataset=gapic_dataset
-        )
-        new_dataset = create_lro.result()
-        shared_state["dataset_name"] = new_dataset.name
-        yield
+        yield dataset
 
-    @pytest.fixture()
-    def create_tabular_dataset(self, dataset_gapic_client, shared_state):
-
-        gapic_dataset = gca_dataset.Dataset(
-            display_name=f"temp_sdk_integration_test_create_tabular_dataset_{uuid.uuid4()}",
-            metadata_schema_uri=aiplatform.schema.dataset.metadata.tabular,
-        )
-
-        create_lro = dataset_gapic_client.create_dataset(
-            parent=_TEST_PARENT, dataset=gapic_dataset
-        )
-        new_dataset = create_lro.result()
-        shared_state["dataset_name"] = new_dataset.name
-        yield
-
-    @pytest.fixture()
-    def create_image_dataset(self, dataset_gapic_client, shared_state):
-
-        gapic_dataset = gca_dataset.Dataset(
-            display_name=f"temp_sdk_integration_test_create_image_dataset_{uuid.uuid4()}",
-            metadata_schema_uri=aiplatform.schema.dataset.metadata.image,
-        )
-
-        create_lro = dataset_gapic_client.create_dataset(
-            parent=_TEST_PARENT, dataset=gapic_dataset
-        )
-        new_dataset = create_lro.result()
-        shared_state["dataset_name"] = new_dataset.name
-        yield
-
-    @pytest.fixture()
-    def delete_new_dataset(self, dataset_gapic_client, shared_state):
-        yield
-        assert shared_state["dataset_name"]
-
-        deletion_lro = dataset_gapic_client.delete_dataset(
-            name=shared_state["dataset_name"]
-        )
-        deletion_lro.result()
-
-        shared_state["dataset_name"] = None
+        dataset.delete()
 
     # TODO(vinnys): Remove pytest skip once persistent resources are accessible
     @pytest.mark.skip(reason="System tests cannot access persistent test resources")
@@ -215,37 +166,23 @@ class TestDataset(e2e_base.TestEndToEnd):
         """Retrieve a known existing dataset, ensure SDK successfully gets the
         dataset resource."""
 
-        aiplatform.init(project=_TEST_PROJECT, location=_TEST_LOCATION)
-
         flowers_dataset = aiplatform.ImageDataset(dataset_name=_TEST_IMAGE_DATASET_ID)
         assert flowers_dataset.name == _TEST_IMAGE_DATASET_ID
         assert flowers_dataset.display_name == _TEST_DATASET_DISPLAY_NAME
 
-    def test_get_nonexistent_dataset(self, shared_state):
+    def test_get_nonexistent_dataset(self):
         """Ensure attempting to retrieve a dataset that doesn't exist raises
         a Google API core 404 exception."""
-
-        shared_state["resources"] = []
-
-        aiplatform.init(project=_TEST_PROJECT, location=_TEST_LOCATION)
 
         # AI Platform service returns 404
         with pytest.raises(exceptions.NotFound):
             aiplatform.ImageDataset(dataset_name="0")
 
-    @pytest.mark.usefixtures("create_text_dataset", "delete_new_dataset")
-    def test_get_new_dataset_and_import(self, dataset_gapic_client, shared_state):
+    def test_get_new_dataset_and_import(self, dataset_gapic_client, text_dataset):
         """Retrieve new, empty dataset and import a text dataset using import().
         Then verify data items were successfully imported."""
 
-        assert shared_state["dataset_name"]
-
-        shared_state["resources"] = []
-
-        aiplatform.init(project=_TEST_PROJECT, location=_TEST_LOCATION)
-
-        my_dataset = aiplatform.TextDataset(dataset_name=shared_state["dataset_name"])
-        shared_state["resources"].extend([my_dataset])
+        my_dataset = aiplatform.TextDataset(dataset_name=text_dataset.name)
 
         data_items_pre_import = dataset_gapic_client.list_data_items(
             parent=my_dataset.resource_name
@@ -266,49 +203,45 @@ class TestDataset(e2e_base.TestEndToEnd):
 
         assert len(list(data_items_post_import)) == 469
 
-    @vpcsc_config.skip_if_inside_vpcsc
-    @pytest.mark.usefixtures("delete_new_dataset")
-    def test_create_and_import_image_dataset(self, dataset_gapic_client, shared_state):
-        """Use the Dataset.create() method to create a new image obj detection
-        dataset and import images. Then confirm images were successfully imported."""
-
-        shared_state["resources"] = []
-
-        aiplatform.init(project=_TEST_PROJECT, location=_TEST_LOCATION)
-
+    @pytest.fixture()
+    def image_dataset(self):
         img_dataset = aiplatform.ImageDataset.create(
             display_name=f"temp_sdk_integration_create_and_import_dataset_{uuid.uuid4()}",
             gcs_source=_TEST_IMAGE_OBJECT_DETECTION_GCS_SOURCE,
             import_schema_uri=_TEST_IMAGE_OBJ_DET_IMPORT_SCHEMA,
             create_request_timeout=None,
         )
-        shared_state["resources"].extend([img_dataset])
 
-        shared_state["dataset_name"] = img_dataset.resource_name
+        yield img_dataset
+
+        img_dataset.delete()
+
+    # @vpcsc_config.skip_if_inside_vpcsc
+    def test_create_and_import_image_dataset(self, dataset_gapic_client, image_dataset):
+        """Use the Dataset.create() method to create a new image obj detection
+        dataset and import images. Then confirm images were successfully imported."""
 
         data_items_iterator = dataset_gapic_client.list_data_items(
-            parent=img_dataset.resource_name
+            parent=image_dataset.resource_name
         )
 
         assert len(list(data_items_iterator)) == 14
 
-    @pytest.mark.usefixtures("delete_new_dataset")
-    def test_create_tabular_dataset(self, dataset_gapic_client, shared_state):
-        """Use the Dataset.create() method to create a new tabular dataset.
-        Then confirm the dataset was successfully created and references GCS source."""
-
-        shared_state["resources"] = []
-
-        aiplatform.init(project=_TEST_PROJECT, location=_TEST_LOCATION)
-
+    @pytest.fixture()
+    def tabular_dataset(self):
         tabular_dataset = aiplatform.TabularDataset.create(
             display_name=f"temp_sdk_integration_create_and_import_dataset_{uuid.uuid4()}",
             gcs_source=[_TEST_TABULAR_CLASSIFICATION_GCS_SOURCE],
             create_request_timeout=None,
         )
-        shared_state["resources"].extend([tabular_dataset])
 
-        shared_state["dataset_name"] = tabular_dataset.resource_name
+        yield tabular_dataset
+
+        tabular_dataset.delete()
+
+    def test_create_tabular_dataset(self, tabular_dataset):
+        """Use the Dataset.create() method to create a new tabular dataset.
+        Then confirm the dataset was successfully created and references GCS source."""
 
         gapic_metadata = tabular_dataset.to_dict()["metadata"]
         gcs_source_uris = gapic_metadata["inputConfig"]["gcsSource"]["uri"]
@@ -320,55 +253,37 @@ class TestDataset(e2e_base.TestEndToEnd):
             == aiplatform.schema.dataset.metadata.tabular
         )
 
-    @pytest.mark.usefixtures("delete_new_dataset")
-    def test_create_tabular_dataset_from_dataframe(
-        self, dataset_gapic_client, shared_state
-    ):
-        """Use the Dataset.create_from_dataframe() method to create a new tabular dataset.
-        Then confirm the dataset was successfully created and references the BQ source."""
-
-        assert shared_state["bigquery_dataset"]
-
-        shared_state["resources"] = []
-
-        bigquery_dataset_id = shared_state["bigquery_dataset_id"]
-        bq_staging_table = f"bq://{bigquery_dataset_id}.test_table{uuid.uuid4()}"
-
-        aiplatform.init(project=_TEST_PROJECT, location=_TEST_LOCATION)
+    @pytest.fixture()
+    def tabular_dataset_from_dataframe(self, bigquery_dataset):
+        bq_staging_table = f"bq://{e2e_base._PROJECT}.{bigquery_dataset.dataset_id}.test_table{uuid.uuid4()}"
 
         tabular_dataset = aiplatform.TabularDataset.create_from_dataframe(
             df_source=_TEST_DATAFRAME,
             staging_path=bq_staging_table,
             display_name=f"temp_sdk_integration_create_and_import_dataset_from_dataframe{uuid.uuid4()}",
         )
-        shared_state["resources"].extend([tabular_dataset])
-        shared_state["dataset_name"] = tabular_dataset.resource_name
 
-        gapic_metadata = tabular_dataset.to_dict()["metadata"]
+        yield tabular_dataset
+
+        tabular_dataset.delete()
+
+    def test_create_tabular_dataset_from_dataframe(
+        self, tabular_dataset_from_dataframe
+    ):
+        """Use the Dataset.create_from_dataframe() method to create a new tabular dataset.
+        Then confirm the dataset was successfully created and references the BQ source."""
+        gapic_metadata = tabular_dataset_from_dataframe.to_dict()["metadata"]
         bq_source = gapic_metadata["inputConfig"]["bigquerySource"]["uri"]
 
-        assert bq_staging_table == bq_source
+        # assert bq_staging_table == bq_source
         assert (
-            tabular_dataset.metadata_schema_uri
+            tabular_dataset_from_dataframe.metadata_schema_uri
             == aiplatform.schema.dataset.metadata.tabular
         )
 
-    @pytest.mark.usefixtures("delete_new_dataset")
-    def test_create_tabular_dataset_from_dataframe_with_provided_schema(
-        self, dataset_gapic_client, shared_state
-    ):
-        """Use the Dataset.create_from_dataframe() method to create a new tabular dataset,
-        passing in the optional `bq_schema` argument. Then confirm the dataset was successfully
-        created and references the BQ source."""
-
-        assert shared_state["bigquery_dataset"]
-
-        shared_state["resources"] = []
-
-        bigquery_dataset_id = shared_state["bigquery_dataset_id"]
-        bq_staging_table = f"bq://{bigquery_dataset_id}.test_table{uuid.uuid4()}"
-
-        aiplatform.init(project=_TEST_PROJECT, location=_TEST_LOCATION)
+    @pytest.fixture()
+    def tabular_dataset_from_dataframe_with_provided_schema(self, bigquery_dataset):
+        bq_staging_table = f"bq://{e2e_base._PROJECT}.{bigquery_dataset.dataset_id}.test_table{uuid.uuid4()}"
 
         tabular_dataset = aiplatform.TabularDataset.create_from_dataframe(
             df_source=_TEST_DATAFRAME,
@@ -376,46 +291,43 @@ class TestDataset(e2e_base.TestEndToEnd):
             display_name=f"temp_sdk_integration_create_and_import_dataset_from_dataframe{uuid.uuid4()}",
             bq_schema=_TEST_DATAFRAME_BQ_SCHEMA,
         )
-        shared_state["resources"].extend([tabular_dataset])
-        shared_state["dataset_name"] = tabular_dataset.resource_name
 
-        gapic_metadata = tabular_dataset.to_dict()["metadata"]
+        yield tabular_dataset
+
+        tabular_dataset.delete()
+
+    def test_create_tabular_dataset_from_dataframe_with_provided_schema(
+        self, tabular_dataset_from_dataframe_with_provided_schema
+    ):
+        """Use the Dataset.create_from_dataframe() method to create a new tabular dataset,
+        passing in the optional `bq_schema` argument. Then confirm the dataset was successfully
+        created and references the BQ source."""
+
+        gapic_metadata = tabular_dataset_from_dataframe_with_provided_schema.to_dict()[
+            "metadata"
+        ]
         bq_source = gapic_metadata["inputConfig"]["bigquerySource"]["uri"]
 
-        assert bq_staging_table == bq_source
+        # assert bq_staging_table == bq_source
         assert (
-            tabular_dataset.metadata_schema_uri
+            tabular_dataset_from_dataframe_with_provided_schema.metadata_schema_uri
             == aiplatform.schema.dataset.metadata.tabular
         )
 
     # TODO(vinnys): Remove pytest skip once persistent resources are accessible
-    @pytest.mark.skip(reason="System tests cannot access persistent test resources")
-    @pytest.mark.usefixtures("create_staging_bucket", "delete_staging_bucket")
-    def test_export_data(self, shared_state):
+    # @pytest.mark.skip(reason="System tests cannot access persistent test resources")
+    def test_export_data(self, storage_client, staging_bucket):
         """Get an existing dataset, export data to a newly created folder in
         Google Cloud Storage, then verify data was successfully exported."""
 
-        assert shared_state["staging_bucket"]
-        assert shared_state["storage_client"]
+        dataset = aiplatform.TextDataset(dataset_name=_TEST_TEXT_DATASET_ID)
 
-        aiplatform.init(
-            project=_TEST_PROJECT,
-            location=_TEST_LOCATION,
-            staging_bucket=f"gs://{shared_state['staging_bucket']}",
-        )
-
-        text_dataset = aiplatform.TextDataset(dataset_name=_TEST_TEXT_DATASET_ID)
-
-        exported_files = text_dataset.export_data(
-            output_dir=f"gs://{shared_state['staging_bucket']}"
-        )
+        exported_files = dataset.export_data(output_dir=f"gs://{staging_bucket.name}")
 
         assert len(exported_files)  # Ensure at least one GCS path was returned
 
         exported_file = exported_files[0]
         bucket, prefix = utils.extract_bucket_and_prefix_from_gcs_path(exported_file)
-
-        storage_client = shared_state["storage_client"]
 
         bucket = storage_client.get_bucket(bucket)
         blob = bucket.get_blob(prefix)


### PR DESCRIPTION
There are two versions:

0c5242dc250311a3123443455b280fbed6197984: This uses try-finally to move cleanup code into each test itself. This looks more straight-forwards and can test things that the fixture method cannot.

675cfcad2085a4935c5bd3a043894220830cfadc: This uses fixtures to hold cleanup code.